### PR TITLE
fixed some service scroll bugs

### DIFF
--- a/app/components/About/About.css
+++ b/app/components/About/About.css
@@ -4,6 +4,7 @@
   justify-content: center;
   box-sizing: border-box;
   width: 100vw;
+  
 }
 
 .about-container {

--- a/app/components/About/About.tsx
+++ b/app/components/About/About.tsx
@@ -1,9 +1,13 @@
-import React from "react";
-import "./About.css"; 
+import React, { useEffect, useRef, useState } from "react";
+import "./About.css";
 
+// currentSection from page.tsx
+interface AboutProps {
+  currentSection: number;
+}
 
+const About: React.FC<AboutProps> = ({ currentSection }) => {
 
-const About: React.FC = () => {
   const handleMouseEnter = () => {
     // Emit a custom event when mouse enters
     window.dispatchEvent(new CustomEvent('about-hover', { detail: { isHovering: true } }));
@@ -13,21 +17,95 @@ const About: React.FC = () => {
     // Emit a custom event when mouse leaves
     window.dispatchEvent(new CustomEvent('about-hover', { detail: { isHovering: false } }));
   };
-  
+
+  const [touchData, setTouchData] = useState<{ startY: number; endY: number | null }>({
+    startY: 0,
+    endY: null,
+  });
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  // Disable scroll behavior while transitioning
+  const disableScroll = () => {
+    document.body.style.pointerEvents = "none";
+    document.body.style.overflow = "hidden";
+  };
+
+  const enableScroll = () => {
+    document.body.style.pointerEvents = "";
+    document.body.style.overflow = "";
+  };
+
+  useEffect(() => {
+    const touchStartHandler = (e: TouchEvent) => {
+      if (e.touches.length === 1) {
+        setTouchData((prev) => ({
+          ...prev,
+          startY: e.touches[0].clientY,
+        }));
+      }
+    };
+
+    const touchMoveHandler = (e: TouchEvent) => {
+      if (isTransitioning) {
+        e.preventDefault();
+        return;
+      }
+
+      const touchEndY = e.touches[0].clientY;
+      const deltaY = touchData.startY - touchEndY;
+
+      if (deltaY > 0 && !isTransitioning && currentSection == 1) {
+        const servicesSection = document.getElementById("services");
+        if (servicesSection) {
+          e.preventDefault(); // Prevent the default scroll behavior
+          // Prevent scroll and trigger transition logic
+          setIsTransitioning(true);
+          disableScroll();
+          // Scroll to the Services section smoothly
+          servicesSection.scrollIntoView({ behavior: "smooth" });
+          // Add your scroll transition logic here
+          setTimeout(() => {
+            servicesSection.scrollIntoView({ behavior: "auto" }); // Ensure alignment
+            setIsTransitioning(false);
+            enableScroll();
+          }, 600); // Adjust timeout to match scroll speed
+
+        }
+
+      }
+
+      setTouchData((prev) => ({ ...prev, endY: touchEndY }));
+    };
+
+    document.addEventListener("touchstart", touchStartHandler, { passive: false });
+    document.addEventListener("touchmove", touchMoveHandler, { passive: false });
+
+    return () => {
+      document.removeEventListener("touchstart", touchStartHandler);
+      document.removeEventListener("touchmove", touchMoveHandler);
+    };
+  }, [touchData, isTransitioning]);
+
+
+
+
+
+
+
   return (
     <section className="about-section">
       <div className="about-container">
-      
+
         <p onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className="about-description">
-        At <strong>NuTab</strong><sup>+</sup>, we see every project as an opportunity to innovate and exceed expectations
+          At <strong>NuTab</strong><sup>+</sup>, we see every project as an opportunity to innovate and exceed expectations
         </p>
 
         <p onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className="about-description">
-        High-quality software that drives client success through expertise, reliability, and efficiency
+          High-quality software that drives client success through expertise, reliability, and efficiency
         </p>
 
         <p onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className="about-description">
-        Custom solutions that connect businesses with technology designed to grow with them
+          Custom solutions that connect businesses with technology designed to grow with them
         </p>
 
       </div>

--- a/app/components/Background/Background.tsx
+++ b/app/components/Background/Background.tsx
@@ -10,7 +10,7 @@ import { gsap } from "gsap";
 // import { useIsMobile } from '../../context/WindowService'; 
 // import { SlowMo } from "gsap/EasePack";
 
-// currentSection from page.tsx and hovered unused for now
+// currentSection from page.tsx
 interface BackgroundProps {
   currentSection: number; // This can be used to control transformations if passed in
 }
@@ -463,7 +463,7 @@ const Background: React.FC<BackgroundProps> = ({ currentSection }) => {
         transform: `translateX(${getHorizontalPosition()})`,
       }}
     >
-      <canvas ref={canvasRef} className="fixed inset-0 z-1 top-7" />
+      <canvas ref={canvasRef} className="fixed inset-0 z-1 top-5" />
     </div>
   );
 };

--- a/app/components/Contact/Contact.css
+++ b/app/components/Contact/Contact.css
@@ -61,6 +61,7 @@ textarea {
 @media (max-width: 600px) {
   .contact-container{
     width: 100vw;
+    margin-bottom: 40vh;
   }
   
 }

--- a/app/components/Services/Services.css
+++ b/app/components/Services/Services.css
@@ -3,12 +3,14 @@
   width: 100%;
   height: 100vh;
   overflow-y: hidden;
+  scroll-snap-type: y mandatory; /* Set snap on the Y-axis (vertical) */
   overflow-x: visible;
   display: grid;
   grid-template-columns: auto;
   color: var(--foreground);
   box-sizing: border-box;
   caret-color: transparent;
+  scroll-behavior: smooth; /* Enables smooth scrolling */
 }
 
 

--- a/app/components/Services/Services.tsx
+++ b/app/components/Services/Services.tsx
@@ -48,7 +48,7 @@ const Services = () => {
           containerRef.current.scrollIntoView({ behavior: "smooth" });
         }
       },
-      { threshold: 0.4 }
+      { threshold: 0.1 }
     );
 
     if (containerRef.current) {
@@ -73,9 +73,12 @@ const Services = () => {
         (currentService === services.length - 1 && e.deltaY > 0)
       ) {
         document.body.style.overflow = "hidden"; // Ensure smooth snapping
-        const scrollOffset = e.deltaY > 0 ? window.innerHeight : -window.innerHeight; // Scroll 100vh up or down
-        window.scrollBy({ top: scrollOffset, behavior: "smooth" });
-        return;
+        const scrollTo = e.deltaY > 0 ? document.getElementById("team") : document.getElementById("about"); // Scroll 135vh up or down
+        if (scrollTo) {
+          scrollTo.scrollIntoView({ behavior: "smooth" });
+          return;
+        }
+        
       }
   
       e.preventDefault(); // Lock scrolling inside the services section
@@ -104,15 +107,28 @@ const Services = () => {
   
   useEffect(() => {
     let touchStartY = 0;
+    let isTouching = false;
+
+    const preventMomentumScrolling = (e: TouchEvent) => {
+      if (isTouching) {
+        e.preventDefault();
+      }
+    };
   
     const touchStartHandler = (e: TouchEvent) => {
       if (e.touches.length === 1) {
         touchStartY = e.touches[0].clientY;
+        isTouching = true;
       }
     };
   
     const touchMoveHandler = (e: TouchEvent) => {
       if (!isInView || isTransitioning || isManualScroll || e.touches.length !== 1) return;
+      const touchMoveY = e.touches[0].clientY;
+      if (Math.abs(touchMoveY - touchStartY) > 10) {
+        // Disable scroll momentum
+        preventMomentumScrolling(e);
+      }
   
       const touchEndY = e.touches[0].clientY;
       const deltaY = touchStartY - touchEndY;
@@ -123,9 +139,12 @@ const Services = () => {
         (currentService === services.length - 1 && deltaY > 0)
       ) {
         document.body.style.overflow = "hidden"; // Ensure smooth snapping
-        const scrollOffset = deltaY > 0 ? window.innerHeight : -window.innerHeight; // Scroll 100vh up or down
-        window.scrollBy({ top: scrollOffset, behavior: "smooth" });
-        return;
+        const scrollTo = deltaY > 0 ? document.getElementById("team") : document.getElementById("about"); // Scroll 135vh up or down
+        if (scrollTo) {
+          scrollTo.scrollIntoView({ behavior: "smooth" });
+          return;
+        }
+        
       }
   
       e.preventDefault(); // Lock scrolling inside the services section

--- a/app/components/Tagline/Tagline.css
+++ b/app/components/Tagline/Tagline.css
@@ -1,7 +1,8 @@
 .tagline-section {
   position: relative;
-  top: 2rem;
+  /* top: 2rem; */
   display: flex;
+  justify-content: center;
   align-items: center;
   width: 50vw;
   box-sizing: border-box;

--- a/app/components/Team/Team.tsx
+++ b/app/components/Team/Team.tsx
@@ -1,7 +1,80 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import "./Team.css";
 
-const Team: React.FC = () => {
+// currentSection from page.tsx
+interface TeamProps {
+  currentSection: number;
+}
+
+const Team: React.FC<TeamProps> = ({ currentSection }) => {
+
+  const [touchData, setTouchData] = useState<{ startY: number; endY: number | null }>({
+    startY: 0,
+    endY: null,
+  });
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  // Disable scroll behavior while transitioning
+  const disableScroll = () => {
+    document.body.style.pointerEvents = "none";
+    document.body.style.overflow = "hidden";
+  };
+
+  const enableScroll = () => {
+    document.body.style.pointerEvents = "";
+    document.body.style.overflow = "";
+  };
+
+  useEffect(() => {
+    const touchStartHandler = (e: TouchEvent) => {
+      if (e.touches.length === 1) {
+        setTouchData((prev) => ({
+          ...prev,
+          startY: e.touches[0].clientY,
+        }));
+      }
+    };
+
+    const touchMoveHandler = (e: TouchEvent) => {
+      if (isTransitioning) {
+        e.preventDefault();
+        return;
+      }
+
+      const touchEndY = e.touches[0].clientY;
+      const deltaY = touchData.startY - touchEndY;
+
+      if (deltaY < 0 && !isTransitioning && currentSection == 3) {
+        const servicesSection = document.getElementById("services");
+        if (servicesSection) {
+          e.preventDefault(); // Prevent the default scroll behavior
+          // Prevent scroll and trigger transition logic
+          setIsTransitioning(true);
+          disableScroll();
+          // Scroll to the Services section smoothly
+          servicesSection.scrollIntoView({ behavior: "smooth" });
+          // Add your scroll transition logic here
+          setTimeout(() => {
+            servicesSection.scrollIntoView({ behavior: "auto" }); // Ensure alignment
+            setIsTransitioning(false);
+            enableScroll();
+          }, 600); // Adjust timeout to match scroll speed
+
+        }
+
+      }
+
+      setTouchData((prev) => ({ ...prev, endY: touchEndY }));
+    };
+
+    document.addEventListener("touchstart", touchStartHandler, { passive: false });
+    document.addEventListener("touchmove", touchMoveHandler, { passive: false });
+
+    return () => {
+      document.removeEventListener("touchstart", touchStartHandler);
+      document.removeEventListener("touchmove", touchMoveHandler);
+    };
+  }, [touchData, isTransitioning]);
   return (
     <section className="team-section">
       <h2 className="team-header">Our Team</h2>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,13 +31,43 @@ const HomePage: React.FC = () => {
           }
         });
       },
-      { threshold: 0.4 }
+      { threshold: 0.2 }
     );
 
     sections.forEach((section) => observer.observe(section));
 
     return () => observer.disconnect();
   }, []);
+
+  // useEffect(() => {
+  //   const handleServicesSnap = () => {
+  //     const servicesSection = document.getElementById("services");
+  //     if (servicesSection) {
+  //       servicesSection.scrollIntoView({ behavior: "smooth", block: "start" });
+  //     }
+  //   };
+  
+  //   const observer = new IntersectionObserver(
+  //     ([entry]) => {
+  //       if (entry.isIntersecting) {
+  //         handleServicesSnap();
+  //       }
+  //     },
+  //     { threshold: 0.5 } // Adjust threshold as needed
+  //   );
+  
+  //   const servicesElement = document.getElementById("services");
+  //   if (servicesElement) {
+  //     observer.observe(servicesElement);
+  //   }
+  
+  //   return () => {
+  //     if (servicesElement) {
+  //       observer.unobserve(servicesElement);
+  //     }
+  //   };
+  // }, []);
+  
 
   // Lock scroll when inside the services section
   useEffect(() => {
@@ -63,7 +93,7 @@ const HomePage: React.FC = () => {
           </section>
 
           <section id="about" className="page-section fade-section align-left" data-section="1">
-            <About />
+            <About currentSection={currentSection} />
           </section>
 
           <section id="services" className="page-section fade-section" data-section="2">
@@ -71,7 +101,7 @@ const HomePage: React.FC = () => {
           </section>
 
           <section id="team" className="page-section fade-section align-left" data-section="3">
-            <Team />
+            <Team currentSection={currentSection} />
           </section>
 
           <section id="contact" className="page-section fade-section align-right" data-section="4">

--- a/app/styles/page.css
+++ b/app/styles/page.css
@@ -17,6 +17,7 @@ the component folder. */
 /* Styling for each section */
 .page-section {
   height: 100vh;
+  margin-bottom: 35vh;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
- added margin bottom to each section
- changed intersection observer thresholds
- passed current section val from page to about and team sections
- added scroll transition from about/team to services section for mobile
- moved model up a bit
- added more margin under contact form -scroll snap to services section
- scroll to section instead of fixed vh when leaving services section
- prevent scroll momentum in services section
- moved tagline container a bit